### PR TITLE
Event redirect

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -88,7 +88,7 @@ class EventsController < ApplicationController
     build_flag_history_from_params @event, event_params, true
     flash[:notice] = 'Event was successfully created.' if @event.save
 
-    respond_with @event
+    respond_with @event, location: -> {root_path}
   end
 
   # PUT /events/1
@@ -105,7 +105,7 @@ class EventsController < ApplicationController
       flash[:notice] = 'Event was successfully updated.' if @event.save
     end
 
-    respond_with @event
+    respond_with @event, location: -> {root_path}
   end
 
   def merge_events

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -88,7 +88,7 @@ class EventsController < ApplicationController
     build_flag_history_from_params @event, event_params, true
     flash[:notice] = 'Event was successfully created.' if @event.save
 
-    respond_with @event, location: -> {root_path}
+    respond_with @event, location: -> {events_path}
   end
 
   # PUT /events/1
@@ -105,7 +105,7 @@ class EventsController < ApplicationController
       flash[:notice] = 'Event was successfully updated.' if @event.save
     end
 
-    respond_with @event, location: -> {root_path}
+    respond_with @event, location: -> {events_path}
   end
 
   def merge_events

--- a/test/functional/events_controller_test.rb
+++ b/test/functional/events_controller_test.rb
@@ -307,7 +307,7 @@ class EventsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to('root') { events_url }
+        should redirect_to('events') { events_url }
       end
 
       context 'GET :edit' do
@@ -326,7 +326,7 @@ class EventsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to('root') { events_url }
+        should redirect_to('events') { events_url }
       end
 
       context 'PUT :update with changed flags' do

--- a/test/functional/events_controller_test.rb
+++ b/test/functional/events_controller_test.rb
@@ -307,7 +307,7 @@ class EventsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to('the item') { event_url assigns(:event) }
+        should redirect_to('root') { events_url }
       end
 
       context 'GET :edit' do
@@ -326,7 +326,7 @@ class EventsControllerTest < ActionController::TestCase
         end
 
         should respond_with :redirect
-        should redirect_to('the item') { event_url @event }
+        should redirect_to('root') { events_url }
       end
 
       context 'PUT :update with changed flags' do


### PR DESCRIPTION
After an event is created or updated, the user is redirected to the events#index view.