### PR TITLE
#135000399 - Remove Messages Tab

### DIFF
--- a/app/views/application/_menubar.html.slim
+++ b/app/views/application/_menubar.html.slim
@@ -7,7 +7,6 @@
       - if current_user and current_user.add_lost_and_found?
         li= tab 'Lost/Found', lost_and_found_path
       - if current_user and current_user.write_entries?
-        li= tab 'Messages', messages_path
         li= tab 'Review', review_events_path
       li= tab 'Duty Board', duty_board_index_path, 'fred'
       - if current_user and current_user.can_assign_radios?

--- a/app/views/contacts/index.html.slim
+++ b/app/views/contacts/index.html.slim
@@ -24,12 +24,7 @@ h1 Contacts
         td= contact.can_text? ? "Yes" : "No"
         td= contact.hotel
         td= contact.hotel_room
-        - if current_user and current_user.write_entries?
-          td= link_to ("Leave&nbsp;Message").html_safe, new_message_path(message: { for: contact.name,
-                                                                                    phone_number: contact.cell_phone,
-                                                                                    room_number: contact.hotel_room,
-                                                                                    hotel: contact.hotel }),
-                      class: 'btn btn-sm btn-primary'
+        
 
 #paginator= paginate @contacts
 = link_to 'New Contact', new_contact_path, class: 'btn btn-primary'
@@ -40,4 +35,3 @@ h1 Contacts
       - if current_user.can_admin_users?
         div= link_to "Users", users_path
         div= link_to "Volunteers", volunteers_path
-      div= link_to "Messages", messages_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,6 @@ ConOnRails::Application.routes.draw do
       get :searchform
     end
   end
-  resources :messages
 
 
   resources :radio_admin, only: [:index]

--- a/test/functional/messages_controller_test.rb
+++ b/test/functional/messages_controller_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class MessagesControllerTest < ActionController::TestCase
+=begin
   setup do
     @message = FactoryGirl.build :valid_message
     @complete_message = FactoryGirl.create :valid_message_with_user
@@ -58,4 +59,5 @@ class MessagesControllerTest < ActionController::TestCase
     put :update, { id: @complete_message.to_param, message: { is_active: false } }, @user_session
     assert assigns( :message ).is_active? == false
   end
+=end
 end


### PR DESCRIPTION
Removed tab, message links in "Contacts" and route to messages controller.  Because the task asked for this feature to be commented out, I didn't remove the message controller, view, or tests.