### PR TITLE
Duty Board now permits 3 columns of groups.

### DIFF
--- a/app/assets/stylesheets/duty_board.css.scss
+++ b/app/assets/stylesheets/duty_board.css.scss
@@ -47,7 +47,7 @@
 
   .duty_board_group
   {
-    @extend .col-md-6;
+    @extend .col-md-4;
 
     //border: thin solid;
     text-align: left;

--- a/app/models/duty_board_group.rb
+++ b/app/models/duty_board_group.rb
@@ -14,7 +14,7 @@ class DutyBoardGroup < ActiveRecord::Base
   has_paper_trail
 
   ROW_RANGE = (1..4)
-  COL_RANGE = (1..2)
+  COL_RANGE = (1..3)
 
   has_many :duty_board_slots, -> { order :name }
   validates_presence_of :name, :row, :column


### PR DESCRIPTION
Still needs a Pivotal story, but this is ready to go.  Requirement was to use 3 columns on duty-board.  This "quick fix" facilitates that, however at some point a more thorough redesign should make the layout truly responsive by removing the column setting in the duty board group, and having different .col-md and .col-lg settings.