### PR TITLE
Add some useful indices!

### DIFF
--- a/db/migrate/20170614174314_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170614174314_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20170614174315_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170614174315_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20170614174316_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170614174316_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/migrate/20170614174809_add_indexes_to_duty_board_groups.rb
+++ b/db/migrate/20170614174809_add_indexes_to_duty_board_groups.rb
@@ -1,0 +1,7 @@
+class AddIndexesToDutyBoardGroups < ActiveRecord::Migration
+  def change
+    add_index :duty_board_groups, :row
+    add_index :duty_board_groups, :column
+    add_index :duty_board_groups, [:row, :column], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170513103526) do
+ActiveRecord::Schema.define(version: 20170614174809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,10 @@ ActiveRecord::Schema.define(version: 20170513103526) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "duty_board_groups", ["column"], name: "index_duty_board_groups_on_column", using: :btree
+  add_index "duty_board_groups", ["row", "column"], name: "index_duty_board_groups_on_row_and_column", unique: true, using: :btree
+  add_index "duty_board_groups", ["row"], name: "index_duty_board_groups_on_row", using: :btree
 
   create_table "duty_board_slots", force: :cascade do |t|
     t.string   "name"
@@ -273,7 +277,15 @@ ActiveRecord::Schema.define(version: 20170513103526) do
     t.datetime "created_at"
   end
 
+  add_index "taggings", ["context"], name: "index_taggings_on_context", using: :btree
   add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+  add_index "taggings", ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+  add_index "taggings", ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+  add_index "taggings", ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+  add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
     t.string  "name"


### PR DESCRIPTION
In addition to the main intended ones for the Duty Board, when I updated my bundle on this machine it showed me that taggable needed some indexes as well (a rake task they call out when you run the bundle). I had noticed that tag look ups looked a little peaky, so I went a head and did that, too.

I am merging this directly, but still calling it to @jshapiro651 's attention as an example of something to watch out for in this and other apps!